### PR TITLE
Raise an exception if RbNaCl has already been loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,28 +8,6 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
-
-## Specific to RubyMotion:
-.dat*
-.repl_history
-build/
-
-## Documentation cache and generated files:
-/.yardoc/
-/_yardoc/
-/doc/
-/rdoc/
-
-## Environment normalisation:
-/.bundle/
-/lib/bundler/man/
-
-# for a library or gem, you might want to ignore these files since the code is
-# intended to run in multiple environments; otherwise, check them in:
+/ext/rbnacl/Makefile
+.rspec_status
 Gemfile.lock
-# .ruby-version
-# .ruby-gemset
-
-# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
-.rvmrc
-/vendor/gems

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+--format=documentation
+--require spec_helper

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ RSpec::Core::RakeTask.new
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
-task default: %w[spec rubocop]
+task default: %w[libsodium spec rubocop]
 
 MAKE = ENV["MAKE"] || ENV["make"] || "make"
 RUBY_CC_VERSION = ENV["RUBY_CC_VERSION"] || "2.3.0"
@@ -18,6 +18,16 @@ task "gem:windows" do
   RakeCompilerDock.sh "cd vendor/libsodium && #{MAKE} clean" if File.exist? "vendor/libsodium/Makefile"
   sh "bundle package" # Avoid repeated downloads of gems by using gem files from the host.
   RakeCompilerDock.sh "bundle --local && RUBY_CC_VERSION=#{RUBY_CC_VERSION} rake cross native gem"
+end
+
+desc "Run autogen"
+task :autogen do
+  cd("vendor/libsodium") { sh "./autogen.sh" }
+end
+
+desc "Compile libsodium"
+task libsodium: :autogen do
+  cd("ext/rbnacl") { load "extconf.rb" }
 end
 
 spec = Gem::Specification.load("rbnacl-libsodium.gemspec")

--- a/ext/rbnacl/Makefile
+++ b/ext/rbnacl/Makefile
@@ -1,0 +1,5 @@
+install:
+	@echo "Nothing to do"
+
+clean:
+	@echo "Nothing to do"

--- a/ext/rbnacl/extconf.rb
+++ b/ext/rbnacl/extconf.rb
@@ -23,7 +23,7 @@ OPTIONS << "--host=#{HOST}" if HOST
 
 CWD = __dir__
 LIBSODIUM_DIR = File.expand_path(File.join(CWD, "..", "..", "vendor", "libsodium"))
-MAKE = ENV["MAKE"] || ENV["make"] || "make"
+MAKE ||= ENV["MAKE"] || ENV["make"] || "make"
 DIST = if HOST
          # install to the stage directory for rake-compiler
          File.expand_path(File.join(CWD, "..", "..", "tmp", RUBY_PLATFORM, "stage", "vendor", "libsodium", "dist"))

--- a/lib/rbnacl/libsodium.rb
+++ b/lib/rbnacl/libsodium.rb
@@ -8,9 +8,12 @@ module RbNaCl
         dist_dirs = ["tmp/#{RUBY_PLATFORM}/stage/vendor/libsodium/dist", "vendor/libsodium/dist"]
         lib_dirs = %w[lib lib64]
         sodiumlib_dirs = dist_dirs.product(lib_dirs).map do |dist_dir, lib_dir|
-          File.expand_path("../../../#{dist_dir}/#{lib_dir}/", __FILE__)
+          File.expand_path("../../#{dist_dir}/#{lib_dir}/", __dir__)
         end
-        sodiumlib_dirs.select { |dir| Dir.exist?(dir) }.first
+
+        sodiumlib_dirs.select { |dir| Dir.exist?(dir) }.first.tap do |dir|
+          raise ExtensionNotFoundError, "libsodium not found!" unless dir
+        end
       end
 
       def sodiumlib_glob
@@ -25,6 +28,20 @@ module RbNaCl
 
     ::RBNACL_LIBSODIUM_GEM_LIB_PATH = Dir.glob(File.join(sodiumlib_dir, sodiumlib_glob)).first
   end
+
+  # Couldn't find our own libsodium build!
+  ExtensionNotFoundError = Class.new(StandardError)
+
+  # A severe error in which two versions of libsodium may wind up linked into
+  # the VM. Since this is a potential memory safety violation, we use Exception
+  # instead of StandardError as a signal the VM is tainted and should probably
+  # exit.
+  #
+  # See https://github.com/crypto-rb/rbnacl-libsodium/issues/24
+  AlreadyLoadedError = Class.new(Exception)
 end
 
-require "rbnacl"
+unless require "rbnacl"
+  # RbNaCl has already been loaded!
+  raise RbNaCl::AlreadyLoadedError, "rbnacl already loaded against system's libsodium! Ruby VM may now be in a bad state"
+end


### PR DESCRIPTION
If this happens, it means a systemwide libsodium is avalable and has already been loaded.